### PR TITLE
[fix] credstash lookup failing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ botocore==1.5.46
 cffi==1.10.0
 click==6.7
 credstash==1.13.2
-cryptography==1.8.1
+cryptography==2.0.3
 docutils==0.13.1
 enum34==1.1.6
 futures==3.1.1


### PR DESCRIPTION
A new method got introduced on cryptography==2.0 named
`load_pem_parameters` of which I had a discussion on #cryptography-d,
possibly failing due to the older version of cryptography installed.

All the 3 tests are passing run using pytest

relevant slack conversation: [https://razorpay.slack.com/archives/C0ZJSSQSV/p1502222997470404](https://razorpay.slack.com/archives/C0ZJSSQSV/p1502222997470404)