### PR TITLE
Update README: fix formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ Installation
 alohomora is distributed via PyPi:
 
 .. code:: shell
+
     pip install razorpay.alohomora
 
 What?


### PR DESCRIPTION
A line break is required for pip install command code formatting